### PR TITLE
Ignore connection-specific header fields

### DIFF
--- a/packages/middleware/src/index.d.ts.map
+++ b/packages/middleware/src/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.js"],"names":[],"mappings":";;AAMA;;;;;GAKG;AACH,oCAHW,MAAM,UACK,mBAAmB,QAAE,kBAAkB,yBAY5D;;;;cAmMY,MAAM,GAAG,GAAG,UAAe,MAAM,kBAAkB,CAAA;2BAInD,OAAO,WAAW,EAAE,eAAe;0BAInC,OAAO,WAAW,EAAE,cAAc"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.js"],"names":[],"mappings":";;AAMA;;;;;GAKG;AACH,oCAHW,MAAM,UACK,mBAAmB,QAAE,kBAAkB,yBAY5D;;;;cAuMY,MAAM,GAAG,GAAG,UAAe,MAAM,kBAAkB,CAAA;2BAInD,OAAO,WAAW,EAAE,eAAe;0BAInC,OAAO,WAAW,EAAE,cAAc"}

--- a/packages/middleware/src/index.js
+++ b/packages/middleware/src/index.js
@@ -162,9 +162,13 @@ const ignoredHeaders = new Set([
   'content-type',
   'dnt',
   'host',
+  'keep-alive',
   'origin',
   'pragma',
+  'proxy-connection',
   'referer',
+  'transfer-encoding',
+  'upgrade',
   'x-grpc-web',
   'x-user-agent',
 ]);


### PR DESCRIPTION
An endpoint must not generate an HTTP/2 message containing connection-specific header fields.
See spec https://httpwg.org/specs/rfc9113.html#rfc.section.8.2.2

For example, when using .NET and the GrpcWebHandler class of Grpc.Net.Client.Web, I found that the transfer-encoding header was set. 